### PR TITLE
[MA-55] Test Controller 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter")
+	implementation("org.springframework.boot:spring-boot-starter-web")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/src/main/java/team/sinseonrich/mkitart/test/presentation/controller/TestController.java
+++ b/src/main/java/team/sinseonrich/mkitart/test/presentation/controller/TestController.java
@@ -1,0 +1,15 @@
+package team.sinseonrich.mkitart.test.presentation.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/test")
+public class TestController {
+
+    @GetMapping
+    public String getTest() {
+        return "This is Team SinseonRich!";
+    }
+}


### PR DESCRIPTION
## 배경
- 웹 어플리케이션을 제공하기 위해 dependency 일부 수정
- Spring Server가 정상적으로 동작하는지 확인하기 위해 Test용 Controller를 하나 생성함

## 상세 내용
- spring boot용 기본 dependency 변경 0fd1d31
   - `spring-boot-starter`에서 `spring-boot-starter-web`로 변경함
- Test용 Controller 추가 5565bc9
   - `TestController` 추가 후 `getTest()` API 구현

## 검증
- Browser를 통해서 API 호출 테스트하여 정상 동작 확인함
![image](https://github.com/team-sinseonrich/mkit-art-backend/assets/21545935/6bd3b4b7-68b7-4a9a-982e-5ad2da24bcef)
