### PR TITLE
[MA-57] Hunspell용 dictionary 파일 추가

### DIFF
--- a/src/main/resources/dictionaries/mkit-art.dic
+++ b/src/main/resources/dictionaries/mkit-art.dic
@@ -1,0 +1,2 @@
+Sinseon
+Mkit


### PR DESCRIPTION
## 배경
- Mkit, Sinseon과 같은 단어들이 오타가 아닌데 Intellij IDEA에서 오타라고 warning을 내줘서, Intellij IDEA에게 오타가 아니라 실제 사용하는 단어라고 알려줄 단어 목록을 생성함

## 상세 내용
- Hunspell용 dictionary 파일 추가 693ad95e3d6e0866341ad8579eb0a05e88828557
   - `mkit-art.dic` 추가
   - Settings에 Editor > Natural Languages > Spelling에서 dic 파일 적용

## 검증
- 기존: Mkit이 typo라고 초록색 밑줄이 그어져 있음
![image](https://github.com/team-sinseonrich/mkit-art-backend/assets/21545935/b1f05bb4-4178-4529-9c48-aeb74c3fd552)
- 변경: 초록색 밑줄이 사라짐
![image](https://github.com/team-sinseonrich/mkit-art-backend/assets/21545935/ed45c018-23e0-4c42-8941-d66d463fab15)